### PR TITLE
Do not use CAS instruction on TARGET_AMIGA

### DIFF
--- a/gcc/config/m68k/m68k.c
+++ b/gcc/config/m68k/m68k.c
@@ -363,7 +363,7 @@ struct gcc_target targetm = TARGET_INITIALIZER;
    */
 #ifdef TARGET_AMIGA
 #define FL_FOR_isa_20    (FL_FOR_isa_10 | FL_ISA_68020 \
-			  | FL_BITFIELD | FL_CAS)
+			  | FL_BITFIELD)
 #else
 #define FL_FOR_isa_20    (FL_FOR_isa_10 | FL_ISA_68020 \
 			  | FL_BITFIELD | FL_68881 | FL_CAS)


### PR DESCRIPTION
TAS/CAS/CAS2 instructions use read-modify-write transfer sequences which are unsupported on amiga hardware.

The problem is explained in detail here: https://retrocomputing.stackexchange.com/questions/1494/was-the-mc680x0s-tas-instruction-forbidden-on-amiga-systems-only-when-operating

