### PR TITLE
Add __amigaos3__ define

### DIFF
--- a/gcc/config/m68k/m68kamigaos.h
+++ b/gcc/config/m68k/m68kamigaos.h
@@ -272,6 +272,7 @@ amiga_declare_object = 0
       builtin_define ("__retfp0=__attribute__((__retfp0__))"); \
       builtin_define_std ("amiga"); \
       builtin_define_std ("amigaos"); \
+      builtin_define_std ("amigaos3"); \
       builtin_define_std ("AMIGA"); \
       builtin_define_std ("MCH_AMIGA"); \
       builtin_assert ("system=amigaos"); \


### PR DESCRIPTION
Add __amigaos3__ define to match amigaos4's __amigaos4__ define, to make porting easier.

So we can do this:
```c
#if defined(__amigaos3__)
#elif defined(__amigaos4__)
#endif
```

Rather than this:
```c
#if defined(__AMIGA__) && !defined(__amigaos4__)
#endif
```

There's also some cases where stuff works on everything else but not os3, so this becomes an issue:
```c
#ifndef __AMIGA__
#endif
```