### PR TITLE
fix gcc for darwin-arm64

### DIFF
--- a/gcc/config.host
+++ b/gcc/config.host
@@ -253,6 +253,10 @@ case ${host} in
     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
     host_xmake_file="${host_xmake_file} i386/x-darwin"
     ;;
+  arm-*-darwin*)
+    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
+    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
+    ;;
   powerpc-*-darwin*)
     out_host_hook_obj="${out_host_hook_obj} host-ppc-darwin.o"
     host_xmake_file="${host_xmake_file} rs6000/x-darwin"

--- a/gcc/config/aarch64/host-aarch64-darwin.c
+++ b/gcc/config/aarch64/host-aarch64-darwin.c
@@ -1,0 +1,30 @@
+/* aarch64-darwin host-specific hook definitions.
+   Copyright (C) 2003-2016 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+#include "hosthooks.h"
+#include "hosthooks-def.h"
+#include "config/host-darwin.h"
+
+/* Darwin doesn't do anything special for aarch64 hosts; this file exists just
+   to include config/host-darwin.h.  */
+
+const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;

--- a/gcc/config/aarch64/x-darwin
+++ b/gcc/config/aarch64/x-darwin
@@ -1,0 +1,3 @@
+host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
+	$(COMPILE) $<
+	$(POSTCOMPILE)

--- a/gcc/config/host-darwin.c
+++ b/gcc/config/host-darwin.c
@@ -1,5 +1,5 @@
 /* Darwin host-specific hook definitions.
-   Copyright (C) 2003-2016 Free Software Foundation, Inc.
+   Copyright (C) 2003-2021 Free Software Foundation, Inc.
 
    This file is part of GCC.
 
@@ -24,7 +24,10 @@
 #include "config/host-darwin.h"
 
 /* Yes, this is really supposed to work.  */
-static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
+/* This allows for a pagesize of 16384, which we have on Darwin20, but should
+   continue to work OK for pagesize 4096 which we have on earlier versions.
+   The size is 1 (binary) Gb.  */
+static char pch_address_space[65536*16384] __attribute__((aligned (16384)));
 
 /* Return the address of the PCH address space, if the PCH will fit in it.  */
 
@@ -58,7 +61,8 @@ darwin_gt_pch_use_address (void *addr, size_t sz, int fd, size_t off)
   sz = (sz + pagesize - 1) / pagesize * pagesize;
 
   if (munmap (pch_address_space + sz, sizeof (pch_address_space) - sz) != 0)
-    fatal_error (input_location, "couldn%'t unmap pch_address_space: %m");
+    fatal_error (input_location,
+		 "could not unmap %<pch_address_space%>: %m");
 
   if (ret)
     {

--- a/libiberty/make-relative-prefix.c
+++ b/libiberty/make-relative-prefix.c
@@ -275,7 +275,7 @@ make_relative_prefix_1 (const char *progname, const char *bin_prefix,
   for (p = bin_prefix, q = prefix; *p && *p == *q; ++p, ++q)
     {}
 
-  p = concat(buf, "/", q, 0);
+  p = concat(buf, "/", q, NULL);
 
   d = opendir(p);
   if (d) closedir(d);
@@ -284,7 +284,7 @@ make_relative_prefix_1 (const char *progname, const char *bin_prefix,
       free(p);
       strcpy(buf, prefix);
       buf[q - prefix] = 0;
-      p = concat(buf, q, 0);
+      p = concat(buf, q, NULL);
     }
   
   //printf("%s %s %s %s ->%s\n", progname, buf, bin_prefix, prefix, p);


### PR DESCRIPTION
This is my attempt to make gcc finally working on Apple Silicon...
Needs the homebrew autodetection fix on [amiga-gcc](https://github.com/bebbo/amiga-gcc/pull/256).

Status:
* `make all` runs fine on native darwin-arm64

@bebbo: Do you have some instructions to perform an in-depth self test of the compiler? If that one passes we are good for release...
