### PR TITLE
Apollo 68080 DBRAL support

### DIFF
--- a/gcc/config/m68k/m68k.md
+++ b/gcc/config/m68k/m68k.md
@@ -7232,9 +7232,11 @@
   CC_STATUS_INIT;
   if (DATA_REG_P (operands[0]))
 	{
-	  if (TUNE_68060 || TUNE_68080)
-		  return "subq%.l #1,%0\;jcc %l1";
-      return "dbra %0,%l1\;clr%.w %0\;subq%.l #1,%0\;jcc %l1";
+    if (TUNE_68080)
+            return "dbral %0,%l1";                 // APOLLO 68080 DBRAL
+    if (TUNE_68060)
+            return "subq%.l #1,%0;jcc %l1";
+    return "dbra %0,%l1;clr%.w %0;subq%.l #1,%0;jcc %l1";
 	}
   if (GET_CODE (operands[0]) == MEM)
     return "subq%.l #1,%0\;jcc %l1";


### PR DESCRIPTION
Hello Stefan,

My name is Willem Drijver and I work in Apollo Team on ApolloOS, ApolloBoot and ApolloCrossDev.

The last project is a toolchain targeted for developers for V4 architecture. Within this project we (developers in the Apollo Team) with great gratitude use your amiga-gcc as an essential component.

Together with Gunnar I am working on improving Apollo 68080 support in GCC, GAS, VASM, etc.

In the past you already implemented some 68080 opcodes like ADDIW and CMPIW.

Here I have a PULL request for adding support for DBRAL (actually it's two PULL's: one for binutils and one for gcc. 

We would be grateful if you could review and if all is OK, approve this change.

I would expect to sent you more PULL request in the near future if that is OK with you.

With regards,

Willem Drijver 
