### PR TITLE
Fix build error when building for macOS on Apple Silicon using the latest macOS SDK

### DIFF
--- a/gcc/graphite.h
+++ b/gcc/graphite.h
@@ -26,6 +26,7 @@ along with GCC; see the file COPYING3.  If not see
 #include <isl/options.h>
 #include <isl/ctx.h>
 #include <isl/val_gmp.h>
+#include <isl/val.h>
 #include <isl/set.h>
 #include <isl/union_set.h>
 #include <isl/map.h>


### PR DESCRIPTION
Compiling gcc 6 under macOS on Apple Silicon would produce a build error when compiling the Graphite code. It just needs one extra ISL header to make it work. This was only an issue for gcc6. Building 13.1 and 13.2 has no issues.

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/0da5638d-52b0-4565-b388-554e3c81cebe">
